### PR TITLE
Fix app-breaking CSP regression (post-#12) + FAQ/manual + Playwright capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+# Run on PRs and on pushes to the long-lived branches. The backend test suite
+# is the gate; the screenshot job is a best-effort smoke capture (uploaded as
+# an artifact) so reviewers can eyeball the UI.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+# Avoid piling up redundant runs when a branch is pushed repeatedly.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Backend tests (node --test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: podcastforge/backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: podcastforge/backend/package-lock.json
+      - run: npm ci
+      - run: npm test
+
+  screenshots:
+    name: Visual capture (Playwright)
+    runs-on: ubuntu-latest
+    needs: test
+    defaults:
+      run:
+        working-directory: podcastforge/backend
+    env:
+      PF_SECRET: ci-screenshot-secret-please-ignore
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: podcastforge/backend/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run screenshots
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: screenshots
+          path: podcastforge/screenshots/
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
           cache: npm
           cache-dependency-path: podcastforge/backend/package-lock.json
       - run: npm ci
+      # Cache the downloaded Chromium across runs (keyed on the installed
+      # Playwright version); the install step then just verifies/installs OS deps.
+      - id: pw-version
+        run: echo "v=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.v }}
       - run: npx playwright install --with-deps chromium
       - run: npm run screenshots
       - uses: actions/upload-artifact@v4

--- a/podcastforge/.claude/skills/run-podcastforge/SKILL.md
+++ b/podcastforge/.claude/skills/run-podcastforge/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: run-podcastforge
+description: Build, run, and drive PodcastForge. Use when asked to start PodcastForge, run its backend tests, take a screenshot of its UI (landing, Guide, FAQ, workspace, account panel), or interact with the running web app.
+---
+
+PodcastForge is a single-page web app: a static frontend (`podcastforge/*.js`,
+`index.html`, `style.css`) served by a dependency-light Node backend
+(`podcastforge/backend/server.js`). An agent drives it with the headless-Chromium
+**driver at `.claude/skills/run-podcastforge/driver.mjs`** — it launches the
+server, drives the page, and writes one screenshot per target.
+
+All paths below are relative to `podcastforge/`.
+
+## Prerequisites
+
+Node ≥ 18 (this container has Node 22). The backend's JSON-store path (used for
+local runs and tests) needs **no npm install** — it only uses Node built-ins;
+`pg` is required lazily and only when `DATABASE_URL` is set.
+
+Driving the UI needs Playwright + a Chromium build. In this container both are
+**already present**: a global `playwright@1.56.1` and its matching Chromium under
+`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`. The driver auto-discovers them (see
+Gotchas), so there is nothing to install here. On a normal machine instead run:
+
+```bash
+cd backend && npm install && npx playwright install chromium
+```
+
+## Run (agent path) — the driver
+
+From `podcastforge/`. The driver spawns its own server (port 5599), captures, and
+tears everything down. Targets are hash anchors (`#guide`, `#faq`), SPA routes
+(`#/generator`, needs `--signup`), or CSS selectors. Screenshots land in
+`./pf-shots/`.
+
+```bash
+# Public marketing sections (no auth)
+node .claude/skills/run-podcastforge/driver.mjs '#guide' '#faq'
+```
+
+```bash
+# Sign up through the real UI, then capture a workspace route
+node .claude/skills/run-podcastforge/driver.mjs --signup '#/generator'
+```
+
+`--signup` flips the app into the workspace (`body.workspace-active`), which
+hides the marketing landing — so a `landing` target *after* `--signup` shows the
+workspace, which is what proves the signup→workspace transition rendered.
+
+## Run (server / API path) — for backend changes
+
+Many backend changes don't need a browser. Launch the server and hit the JSON API
+with `curl`:
+
+```bash
+cd backend && PF_SECRET=dev PORT=3010 node server.js &
+sleep 1
+curl -s http://127.0.0.1:3010/api/health
+curl -s -X POST http://127.0.0.1:3010/api/auth/signup \
+  -H 'content-type: application/json' \
+  -d '{"email":"smoke@example.com","password":"smoke-pass-123"}'
+# stop it:  kill %1
+```
+
+`/api/health` returns the provider list; signup returns `{token,user}`. Auth'd
+calls take `Authorization: Bearer <token>`.
+
+## Test
+
+```bash
+cd backend && npm test
+```
+
+Runs `node --test` (security + rate-limit + live-server suite). Uses the JSON
+store; writes a throwaway `backend/data/db.json` (gitignored).
+
+## Gotchas (the battle scars)
+
+- **Playwright version vs. browser build.** The repo pins `playwright@1.61`
+  (wants Chromium build 1228), but this container only has build **1194** +
+  global **`playwright@1.56.1`**. `npm run screenshots` (which imports the local
+  1.61) therefore fails here with "browser not found". `driver.mjs` avoids this:
+  it tries `playwright` locally, then falls back to the global install next to
+  the node binary (`/opt/nodeXX/lib/node_modules`), launching with the first
+  module whose browser actually exists. The launch log prints which one it used.
+- **`npx playwright install chromium` is blocked in this sandbox** — the download
+  host `cdn.playwright.dev` isn't in the egress allowlist (403). Don't try to
+  install a browser here; rely on the preinstalled one (the driver does).
+- **Run Chromium with `--no-sandbox`.** The container runs as root; the default
+  sandbox aborts launch. The driver already passes it.
+- **SPA routes aren't CSS selectors.** `#/generator` is a hash route, not an id —
+  navigate to it and full-page screenshot; only simple `#section` anchors
+  (`#faq`) can be element-cropped. The driver distinguishes them.
+- **External CDNs are non-fatal.** The page pulls GSAP/Lenis/Razorpay/Google
+  Fonts from CDNs; `app.js` guards every global, so the SPA boots and is drivable
+  even when those are slow or blocked. The driver waits for `window.app &&
+  window.PF` (real readiness) instead of a fixed sleep.
+- **Fake keys are fine for UI.** The backend stores any 8–400 char key (it
+  detects the provider from the prefix and encrypts it) without calling the
+  provider — so `gsk_...` demos the Groq "transcribes" tag without a real key.
+
+## Troubleshooting
+
+- `LAUNCH FAIL: ... Executable doesn't exist` / "browser not found" → you're on
+  the local `playwright@1.61` with no matching browser. Use the driver (it falls
+  back to global), or set `PLAYWRIGHT_MODULE=/opt/node22/lib/node_modules/playwright`.
+- `server did not become ready` → another process holds the port. Change `PORT`
+  or kill the stale `node server.js`.
+- Blank/error screenshot → check the `[page error]` lines the driver prints, and
+  confirm the server logged no boot error (it refuses to start if
+  `NODE_ENV=production` and `PF_SECRET` is unset — the driver sets `PF_SECRET`).
+
+## Secondary: full visual capture (CI)
+
+`cd backend && npm run screenshots` runs `scripts/screenshots.mjs`, the
+multi-screen capture wired into GitHub Actions (it uploads `podcastforge/screenshots/`
+as a build artifact). It imports the **local** Playwright, so it needs
+`npx playwright install chromium` to have succeeded — it runs in CI, not in this
+browser-download-blocked sandbox. For ad-hoc local driving, use `driver.mjs` above.

--- a/podcastforge/.claude/skills/run-podcastforge/driver.mjs
+++ b/podcastforge/.claude/skills/run-podcastforge/driver.mjs
@@ -1,0 +1,130 @@
+/* ============================================================
+   PodcastForge — run-skill driver
+   Launches the backend (which serves the SPA), drives a headless
+   Chromium, optionally signs up to enter the workspace, and writes a
+   screenshot per target. This is the agent's handle on the running app.
+
+   Usage (from podcastforge/):
+     node .claude/skills/run-podcastforge/driver.mjs                 # landing -> pf-shots/landing.png
+     node .claude/skills/run-podcastforge/driver.mjs '#guide' '#faq' # element/route shots
+     node .claude/skills/run-podcastforge/driver.mjs --signup '#/generator'  # workspace route
+
+   A target is either a hash route ('#faq', '#/generator') or a CSS
+   selector ('.faq-item'). Workspace routes ('#/...') need --signup.
+
+   Env: PORT (default 5599), PF_SECRET, PW_OUT (output dir, default
+   ./pf-shots), PLAYWRIGHT_MODULE (force a specific playwright module).
+   ============================================================ */
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const backendDir = path.resolve(__dirname, '..', '..', '..', 'backend');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const args = process.argv.slice(2);
+const signup = args.includes('--signup');
+const targets = args.filter((a) => a !== '--signup');
+const outDir = path.resolve(process.env.PW_OUT || path.join(process.cwd(), 'pf-shots'));
+fs.mkdirSync(outDir, { recursive: true });
+
+const PORT = process.env.PORT || 5599;
+const BASE = `http://127.0.0.1:${PORT}`;
+
+// Resolve a working Chromium. Tries the local devDep first, then a global
+// install next to the node binary (e.g. /opt/nodeXX/lib/node_modules) — whose
+// pre-installed browser may be the only one present in a sandbox. Returns the
+// first module whose chromium actually launches.
+async function launchChromium(opts) {
+  const specs = [];
+  if (process.env.PLAYWRIGHT_MODULE) specs.push(process.env.PLAYWRIGHT_MODULE);
+  specs.push('playwright', 'playwright-core');
+  const globalDir = path.join(path.dirname(process.execPath), '..', 'lib', 'node_modules');
+  specs.push(path.join(globalDir, 'playwright'), path.join(globalDir, 'playwright-core'));
+  let lastErr;
+  for (const spec of specs) {
+    let mod;
+    try { mod = require(spec); } catch { continue; }
+    if (!mod || !mod.chromium) continue;
+    try {
+      const b = await mod.chromium.launch(opts);
+      console.log(`[driver] launched Chromium via "${spec}" (${b.version()})`);
+      return b;
+    } catch (e) { lastErr = e; }   // e.g. a playwright whose browser isn't installed
+  }
+  throw lastErr || new Error('No usable Playwright/Chromium found. Run: npx playwright install chromium');
+}
+
+async function waitForServer(url, tries = 60) {
+  for (let i = 0; i < tries; i++) {
+    try { if ((await fetch(url + '/api/health')).ok) return; } catch { /* not up yet */ }
+    await sleep(250);
+  }
+  throw new Error('server did not become ready');
+}
+
+const slug = (t) => t.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '') || 'shot';
+
+async function main() {
+  const server = spawn('node', ['server.js'], {
+    cwd: backendDir,
+    env: { ...process.env, PORT: String(PORT), PF_SECRET: process.env.PF_SECRET || 'run-driver-secret' },
+    stdio: 'inherit'
+  });
+  const killServer = () => { try { server.kill('SIGTERM'); } catch {} };
+  await waitForServer(BASE);
+
+  const browser = await launchChromium({ args: ['--no-sandbox'] });
+  const captured = [];
+  try {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2, reducedMotion: 'reduce' });
+    const page = await ctx.newPage();
+    page.on('pageerror', (e) => console.error('[page error]', e.message));
+    await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => window.app && window.PF, { timeout: 15000 }).catch(() => {});
+
+    if (signup) {
+      await page.evaluate(() => window.app && window.app.showAuthModal());
+      await page.fill('#auth-email', `run_${Date.now()}@example.com`);
+      await page.fill('#auth-password', 'run-driver-pass-123');
+      await page.click('#auth-submit');
+      await page.waitForSelector('body.workspace-active', { timeout: 15000 });
+      await sleep(800);
+      console.log('[driver] signed up -> workspace');
+    }
+
+    const list = targets.length ? targets : ['landing'];
+    for (const t of list) {
+      const file = path.join(outDir, `${slug(t)}.png`);
+      if (t === 'landing') {
+        await page.screenshot({ path: file, fullPage: true });
+      } else if (t.startsWith('#')) {
+        await page.goto(`${BASE}/${t}`, { waitUntil: 'domcontentloaded' });
+        await sleep(700);
+        await page.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
+        // A simple "#section" anchor maps to an element id we can crop to; a
+        // SPA route like "#/generator" does not — capture the full page.
+        const isAnchor = /^#[A-Za-z][\w-]*$/.test(t);
+        const el = isAnchor ? page.locator(t).first() : null;
+        if (el && (await el.count())) { await el.scrollIntoViewIfNeeded(); await el.screenshot({ path: file }); }
+        else { await page.screenshot({ path: file, fullPage: true }); }
+      } else {
+        const el = page.locator(t).first();
+        await el.scrollIntoViewIfNeeded();
+        await el.screenshot({ path: file });
+      }
+      captured.push(file);
+      console.log(`[driver] captured ${t} -> ${file}`);
+    }
+  } finally {
+    await browser.close().catch(() => {});
+    killServer();
+  }
+  console.log(`\n[driver] ${captured.length} screenshot(s) in ${outDir}`);
+}
+
+main().catch((e) => { console.error('[driver]', e.message); process.exit(1); });

--- a/podcastforge/.gitignore
+++ b/podcastforge/.gitignore
@@ -1,0 +1,2 @@
+# Generated visual-capture output (npm run screenshots)
+screenshots/

--- a/podcastforge/.gitignore
+++ b/podcastforge/.gitignore
@@ -1,2 +1,3 @@
-# Generated visual-capture output (npm run screenshots)
+# Generated visual-capture output (npm run screenshots / run-skill driver)
 screenshots/
+pf-shots/

--- a/podcastforge/app.js
+++ b/podcastforge/app.js
@@ -436,8 +436,14 @@ const PROVIDER_MODELS = {
 
 const PROVIDER_LABELS = {
   anthropic: 'Anthropic', gemini: 'Google Gemini', openrouter: 'OpenRouter',
-  nvidia: 'NVIDIA NIM', openai: 'OpenAI'
+  nvidia: 'NVIDIA NIM', openai: 'OpenAI', groq: 'Groq'
 };
+
+// Providers whose keys can ALSO turn episode audio into a transcript (Whisper
+// for OpenAI/Groq, multimodal for Gemini) — mirrors the backend STT_ORDER.
+// Groq is free and Gemini is one most users already have, so transcription
+// doesn't require a paid OpenAI key.
+const STT_PROVIDERS = ['openai', 'groq', 'gemini'];
 
 function buildRequest(provider, model, key, systemPrompt, userPrompt) {
   if (provider === 'anthropic') {
@@ -1181,7 +1187,16 @@ function renderAccount(d) {
 
   h += `<div class="ac-sec"><div class="ac-h">Connected API keys</div>`;
   if ((u.providers || []).length) {
-    u.providers.forEach(p => { h += `<div class="ac-row"><span>🔑 ${e(p)}</span><button class="ac-rm" onclick="app.removeProviderKey('${e(p)}')">Remove</button></div>`; });
+    u.providers.forEach(p => {
+      const stt = STT_PROVIDERS.includes(p);
+      h += `<div class="ac-row"><span>🔑 ${e(PROVIDER_LABELS[p] || p)}${stt ? ' <span class="ac-tag" title="This key can transcribe podcast audio">🎙 transcribes</span>' : ''}</span><button class="ac-rm" onclick="app.removeProviderKey('${e(p)}')">Remove</button></div>`;
+    });
+    const sttKeys = (u.providers || []).filter(p => STT_PROVIDERS.includes(p));
+    if (sttKeys.length) {
+      h += `<div class="ac-hint ac-hint-ok">🎙 Audio transcription is available via ${sttKeys.map(p => e(PROVIDER_LABELS[p] || p)).join(', ')}. Episodes without a published transcript can be generated from audio in the Transcripts tool.</div>`;
+    } else {
+      h += `<div class="ac-hint">🎙 None of your keys can transcribe audio yet. Add a <b>Groq</b> (free) or <b>Google Gemini</b> key to generate transcripts from episodes that don't publish one — no paid OpenAI key required.</div>`;
+    }
   } else h += `<div class="ac-muted">No keys stored. Add one in the workspace key bar.</div>`;
   h += `</div>`;
 

--- a/podcastforge/backend/README.md
+++ b/podcastforge/backend/README.md
@@ -98,6 +98,24 @@ browser.
 `GET /api/health` → `{ ok: true, providers: [...] }`. Point your host's health
 check here.
 
+## Visual capture (screenshots)
+
+A Playwright script boots the server, drives a headless Chromium through the
+key screens (landing, the Guide and FAQ, the workspace, and the account panel's
+"which keys can transcribe" hint, plus a mobile FAQ shot) and writes PNGs to
+`../screenshots/`:
+
+```bash
+npm install                       # installs playwright (devDependency)
+npx playwright install chromium   # one-time browser download
+npm run screenshots               # -> podcastforge/screenshots/*.png
+```
+
+Each shot is independent, so one failure won't abort the rest. Point it at an
+already-running instance with `PW_BASE_URL=https://your-host` (it then skips
+spawning a local server). Note: the browser download needs egress to
+`cdn.playwright.dev`, which is blocked in some sandboxes.
+
 ## Security posture
 
 Built-in, zero-dependency hardening:

--- a/podcastforge/backend/lib/oauth.js
+++ b/podcastforge/backend/lib/oauth.js
@@ -79,19 +79,27 @@ async function fetchProfile(provider, accessToken) {
   const u = await r.json().catch(() => ({}));
   if (!r.ok || !u.id) throw new Error('Could not read GitHub profile.');
 
-  // Always resolve the email from the verified-emails endpoint rather than
-  // trusting the profile's `email` field. Accounts are linked by email, so a
-  // non-verified address must never be accepted — that would let someone claim
-  // an account whose email they don't actually control.
-  const er = await fetch('https://api.github.com/user/emails', {
-    headers: { Authorization: `Bearer ${accessToken}`, 'User-Agent': 'PodcastForge', Accept: 'application/vnd.github+json' },
-    signal: AbortSignal.timeout(15000)
-  });
-  const list = await er.json().catch(() => []);
-  const primary = Array.isArray(list)
-    ? (list.find(e => e.primary && e.verified) || list.find(e => e.verified))
-    : null;
-  const email = primary && primary.email;
+  // Prefer the verified-emails endpoint so we only ever accept a verified
+  // address (accounts are linked by email — accepting an unverified one would
+  // let someone claim an account whose email they don't control). If that call
+  // is unavailable (transient 5xx/timeout/rate-limit), fall back to the
+  // profile's public `email`, which GitHub only exposes when it is itself a
+  // verified address — so the verification guarantee still holds.
+  let email = null;
+  try {
+    const er = await fetch('https://api.github.com/user/emails', {
+      headers: { Authorization: `Bearer ${accessToken}`, 'User-Agent': 'PodcastForge', Accept: 'application/vnd.github+json' },
+      signal: AbortSignal.timeout(15000)
+    });
+    if (er.ok) {
+      const list = await er.json().catch(() => []);
+      const primary = Array.isArray(list)
+        ? (list.find(e => e.primary && e.verified) || list.find(e => e.verified))
+        : null;
+      email = primary && primary.email;
+    }
+  } catch (e) { /* fall back to the (verified) public profile email below */ }
+  if (!email) email = u.email || null;
   if (!email) throw new Error('No verified email on your GitHub account.');
   return { email, providerId: String(u.id), name: u.name || u.login || '' };
 }

--- a/podcastforge/backend/lib/ratelimit.js
+++ b/podcastforge/backend/lib/ratelimit.js
@@ -47,7 +47,12 @@ function check(bucket, id, max, windowMs) {
   };
 }
 
+// Clear a single (bucket, id) window. Called after a successful auth so that
+// legitimate users (e.g. many people behind one NAT/proxy IP) don't accumulate
+// toward the brute-force lockout — only failing attempts keep counting.
+function reset(bucket, id) { hits.delete(`${bucket}:${id}`); }
+
 // Test/maintenance helper.
 function _reset() { hits.clear(); }
 
-module.exports = { check, _reset };
+module.exports = { check, reset, _reset };

--- a/podcastforge/backend/package-lock.json
+++ b/podcastforge/backend/package-lock.json
@@ -12,7 +12,8 @@
         "pg": "^8.21.0"
       },
       "devDependencies": {
-        "pg-mem": "^3.0.14"
+        "pg-mem": "^3.0.14",
+        "playwright": "^1.61.0"
       },
       "engines": {
         "node": ">=18"
@@ -146,6 +147,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -540,6 +556,38 @@
       "dependencies": {
         "moo": "^0.5.1",
         "nearley": "^2.19.5"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postgres-array": {

--- a/podcastforge/backend/package.json
+++ b/podcastforge/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --test"
+    "test": "node --test",
+    "screenshots": "node scripts/screenshots.mjs"
   },
   "engines": {
     "node": ">=18"
@@ -15,6 +16,7 @@
     "pg": "^8.21.0"
   },
   "devDependencies": {
-    "pg-mem": "^3.0.14"
+    "pg-mem": "^3.0.14",
+    "playwright": "^1.61.0"
   }
 }

--- a/podcastforge/backend/scripts/screenshots.mjs
+++ b/podcastforge/backend/scripts/screenshots.mjs
@@ -69,83 +69,99 @@ async function main() {
   const page = await context.newPage();
   const results = [];
 
-  async function shot(name, fn) {
+  // `required` shots gate CI — the public pages that must always render. Auth-
+  // dependent shots are best-effort and never fail the build (they can flake on
+  // a fresh DB / slow CDN), but a broken landing/Guide/FAQ is a real regression.
+  async function shot(name, required, fn) {
     try {
       await fn();
-      const file = path.join(outDir, name);
-      results.push({ name, ok: true });
-      return file;
+      results.push({ name, ok: true, required });
     } catch (e) {
-      results.push({ name, ok: false, err: e.message });
+      results.push({ name, ok: false, required, err: e.message });
       console.error(`[screenshots] ${name} failed: ${e.message}`);
     }
   }
 
-  await page.goto(BASE, { waitUntil: 'domcontentloaded' });
-  await sleep(800); // let scripts boot
+  try {
+    await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+    // Wait for the SPA to finish booting rather than guessing with a sleep, so
+    // shots don't race app init (which lazily pulls the animation CDNs).
+    await page.waitForFunction(() => window.app && window.PF, { timeout: 15000 }).catch(() => {});
 
-  // 1) Full landing page
-  await shot('01-landing.png', async () => {
-    await page.screenshot({ path: path.join(outDir, '01-landing.png'), fullPage: true });
-  });
+    // 1) Full landing page
+    await shot('01-landing.png', true, async () => {
+      await page.screenshot({ path: path.join(outDir, '01-landing.png'), fullPage: true });
+    });
 
-  // 2) User manual / Guide section
-  await shot('02-guide.png', async () => {
-    const el = page.locator('#guide');
-    await el.scrollIntoViewIfNeeded();
-    await el.screenshot({ path: path.join(outDir, '02-guide.png') });
-  });
+    // 2) User manual / Guide section
+    await shot('02-guide.png', true, async () => {
+      const el = page.locator('#guide');
+      await el.scrollIntoViewIfNeeded();
+      await el.screenshot({ path: path.join(outDir, '02-guide.png') });
+    });
 
-  // 3) FAQ — expand every accordion item first
-  await shot('03-faq.png', async () => {
-    await page.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
-    const el = page.locator('#faq');
-    await el.scrollIntoViewIfNeeded();
-    await el.screenshot({ path: path.join(outDir, '03-faq.png') });
-  });
+    // 3) FAQ — expand every accordion item first
+    await shot('03-faq.png', true, async () => {
+      await page.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
+      const el = page.locator('#faq');
+      await el.scrollIntoViewIfNeeded();
+      await el.screenshot({ path: path.join(outDir, '03-faq.png') });
+    });
 
-  // 4) Workspace — sign up through the real UI so the transition is genuine
-  await shot('04-workspace.png', async () => {
-    const email = `shot_${Date.now()}@example.com`;
-    await page.evaluate(() => window.app && window.app.showAuthModal());
-    await page.fill('#auth-email', email);
-    await page.fill('#auth-password', 'screenshot-pass-123');
-    await page.click('#auth-submit');
-    await page.waitForSelector('body.workspace-active', { timeout: 15000 });
-    await sleep(1000);
-    await page.screenshot({ path: path.join(outDir, '04-workspace.png') });
-  });
+    // 4) Workspace — sign up through the real UI so the transition is genuine
+    await shot('04-workspace.png', false, async () => {
+      const email = `shot_${Date.now()}@example.com`;
+      await page.evaluate(() => window.app && window.app.showAuthModal());
+      await page.fill('#auth-email', email);
+      await page.fill('#auth-password', 'screenshot-pass-123');
+      await page.click('#auth-submit');
+      await page.waitForSelector('body.workspace-active', { timeout: 15000 });
+      await sleep(1000);
+      await page.screenshot({ path: path.join(outDir, '04-workspace.png') });
+    });
 
-  // 5) Account panel showing the "which keys can transcribe" hint. Save a
-  //    (fake) Groq key so the 🎙 transcribes tag + green hint render.
-  await shot('05-account-transcribe.png', async () => {
-    await page.evaluate(async () => { try { await window.PF.saveKey('gsk_screenshotdemoKEY000000000000'); } catch {} });
-    await page.evaluate(() => window.app && window.app.openAccount());
-    await page.waitForSelector('#account-modal.show .ac-hint', { timeout: 10000 });
-    await sleep(400);
-    await page.screenshot({ path: path.join(outDir, '05-account-transcribe.png') });
-  });
+    // 5) Account panel showing the "which keys can transcribe" hint. Save a
+    //    (fake) Groq key so the 🎙 transcribes tag + green hint render. If the
+    //    save fails (e.g. shot 04 didn't authenticate) this shot fails loudly
+    //    rather than capturing the wrong "no keys" panel.
+    await shot('05-account-transcribe.png', false, async () => {
+      await page.evaluate(() => window.PF.saveKey('gsk_screenshotdemoKEY000000000000'));
+      await page.evaluate(() => window.app && window.app.openAccount());
+      await page.waitForSelector('#account-modal.show .ac-hint', { timeout: 10000 });
+      await sleep(400);
+      await page.screenshot({ path: path.join(outDir, '05-account-transcribe.png') });
+    });
 
-  // 6) FAQ on a mobile viewport (responsive check)
-  await shot('06-faq-mobile.png', async () => {
-    const mobile = await browser.newContext({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2, reducedMotion: 'reduce', isMobile: true });
-    const mp = await mobile.newPage();
-    await mp.goto(BASE, { waitUntil: 'domcontentloaded' });
-    await mp.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
-    const el = mp.locator('#faq');
-    await el.scrollIntoViewIfNeeded();
-    await el.screenshot({ path: path.join(outDir, '06-faq-mobile.png') });
-    await mobile.close();
-  });
-
-  await browser.close();
-  killServer();
+    // 6) FAQ on a mobile viewport (responsive check)
+    await shot('06-faq-mobile.png', false, async () => {
+      const mobile = await browser.newContext({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2, reducedMotion: 'reduce', isMobile: true });
+      try {
+        const mp = await mobile.newPage();
+        await mp.goto(BASE, { waitUntil: 'domcontentloaded' });
+        await mp.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
+        const el = mp.locator('#faq');
+        await el.scrollIntoViewIfNeeded();
+        await el.screenshot({ path: path.join(outDir, '06-faq-mobile.png') });
+      } finally {
+        await mobile.close();
+      }
+    });
+  } finally {
+    // Always tear down, even if a shot throws unexpectedly, so the job never
+    // hangs on the still-listening server child.
+    await browser.close().catch(() => {});
+    killServer();
+  }
 
   const ok = results.filter((r) => r.ok).length;
+  const failedRequired = results.filter((r) => r.required && !r.ok);
   console.log(`\n[screenshots] ${ok}/${results.length} captured -> ${outDir}`);
-  results.forEach((r) => console.log(`  ${r.ok ? '✓' : '✗'} ${r.name}${r.err ? '  (' + r.err + ')' : ''}`));
-  // Non-zero exit if everything failed, so CI/users notice.
-  if (ok === 0) process.exit(1);
+  results.forEach((r) => console.log(`  ${r.ok ? '✓' : '✗'} ${r.name}${r.required ? '' : ' (optional)'}${r.err ? '  (' + r.err + ')' : ''}`));
+  // Fail CI only if a REQUIRED (public) shot failed; auth-dependent shots warn.
+  if (failedRequired.length) {
+    console.error(`[screenshots] ${failedRequired.length} required shot(s) failed.`);
+    process.exit(1);
+  }
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/podcastforge/backend/scripts/screenshots.mjs
+++ b/podcastforge/backend/scripts/screenshots.mjs
@@ -1,0 +1,151 @@
+/* ============================================================
+   PodcastForge — visual capture (Playwright)
+   Boots the backend (which serves the frontend), drives a headless
+   Chromium through the key screens, and writes PNGs to
+   ../screenshots/. Resilient: each shot is independent, so one
+   failure never aborts the rest.
+
+   Usage (from backend/):
+     npm install                      # installs playwright (devDep)
+     npx playwright install chromium  # one-time browser download
+     npm run screenshots              # -> podcastforge/screenshots/*.png
+
+   Env overrides: PORT, PF_SECRET, PW_BASE_URL (skip spawning a server
+   and shoot an already-running instance instead).
+   ============================================================ */
+import { spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const backendDir = path.resolve(__dirname, '..');
+const outDir = path.resolve(backendDir, '..', 'screenshots');
+fs.mkdirSync(outDir, { recursive: true });
+
+const PORT = process.env.PORT || 4123;
+const BASE = process.env.PW_BASE_URL || `http://127.0.0.1:${PORT}`;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForServer(url, tries = 60) {
+  for (let i = 0; i < tries; i++) {
+    try { if ((await fetch(url + '/api/health')).ok) return true; } catch { /* not up yet */ }
+    await sleep(250);
+  }
+  throw new Error('server did not become ready');
+}
+
+async function main() {
+  // Spawn our own server unless pointed at an external URL.
+  let server = null;
+  if (!process.env.PW_BASE_URL) {
+    server = spawn('node', ['server.js'], {
+      cwd: backendDir,
+      env: { ...process.env, PORT: String(PORT), PF_SECRET: process.env.PF_SECRET || 'screenshot-secret-please-ignore' },
+      stdio: 'inherit'
+    });
+    await waitForServer(BASE);
+  }
+  const killServer = () => { if (server) { try { server.kill('SIGTERM'); } catch {} } };
+
+  let browser;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    console.error('\n[screenshots] Could not launch Chromium. Run `npx playwright install chromium` first.');
+    console.error('              (In sandboxes, cdn.playwright.dev must be allow-listed for that download.)\n');
+    killServer();
+    throw e;
+  }
+
+  // reducedMotion makes scroll-reveal content render immediately and stops
+  // captures landing mid-animation; deviceScaleFactor:2 yields crisp PNGs.
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+    reducedMotion: 'reduce'
+  });
+  const page = await context.newPage();
+  const results = [];
+
+  async function shot(name, fn) {
+    try {
+      await fn();
+      const file = path.join(outDir, name);
+      results.push({ name, ok: true });
+      return file;
+    } catch (e) {
+      results.push({ name, ok: false, err: e.message });
+      console.error(`[screenshots] ${name} failed: ${e.message}`);
+    }
+  }
+
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+  await sleep(800); // let scripts boot
+
+  // 1) Full landing page
+  await shot('01-landing.png', async () => {
+    await page.screenshot({ path: path.join(outDir, '01-landing.png'), fullPage: true });
+  });
+
+  // 2) User manual / Guide section
+  await shot('02-guide.png', async () => {
+    const el = page.locator('#guide');
+    await el.scrollIntoViewIfNeeded();
+    await el.screenshot({ path: path.join(outDir, '02-guide.png') });
+  });
+
+  // 3) FAQ — expand every accordion item first
+  await shot('03-faq.png', async () => {
+    await page.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
+    const el = page.locator('#faq');
+    await el.scrollIntoViewIfNeeded();
+    await el.screenshot({ path: path.join(outDir, '03-faq.png') });
+  });
+
+  // 4) Workspace — sign up through the real UI so the transition is genuine
+  await shot('04-workspace.png', async () => {
+    const email = `shot_${Date.now()}@example.com`;
+    await page.evaluate(() => window.app && window.app.showAuthModal());
+    await page.fill('#auth-email', email);
+    await page.fill('#auth-password', 'screenshot-pass-123');
+    await page.click('#auth-submit');
+    await page.waitForSelector('body.workspace-active', { timeout: 15000 });
+    await sleep(1000);
+    await page.screenshot({ path: path.join(outDir, '04-workspace.png') });
+  });
+
+  // 5) Account panel showing the "which keys can transcribe" hint. Save a
+  //    (fake) Groq key so the 🎙 transcribes tag + green hint render.
+  await shot('05-account-transcribe.png', async () => {
+    await page.evaluate(async () => { try { await window.PF.saveKey('gsk_screenshotdemoKEY000000000000'); } catch {} });
+    await page.evaluate(() => window.app && window.app.openAccount());
+    await page.waitForSelector('#account-modal.show .ac-hint', { timeout: 10000 });
+    await sleep(400);
+    await page.screenshot({ path: path.join(outDir, '05-account-transcribe.png') });
+  });
+
+  // 6) FAQ on a mobile viewport (responsive check)
+  await shot('06-faq-mobile.png', async () => {
+    const mobile = await browser.newContext({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2, reducedMotion: 'reduce', isMobile: true });
+    const mp = await mobile.newPage();
+    await mp.goto(BASE, { waitUntil: 'domcontentloaded' });
+    await mp.evaluate(() => document.querySelectorAll('#faq details').forEach((d) => (d.open = true)));
+    const el = mp.locator('#faq');
+    await el.scrollIntoViewIfNeeded();
+    await el.screenshot({ path: path.join(outDir, '06-faq-mobile.png') });
+    await mobile.close();
+  });
+
+  await browser.close();
+  killServer();
+
+  const ok = results.filter((r) => r.ok).length;
+  console.log(`\n[screenshots] ${ok}/${results.length} captured -> ${outDir}`);
+  results.forEach((r) => console.log(`  ${r.ok ? '✓' : '✗'} ${r.name}${r.err ? '  (' + r.err + ')' : ''}`));
+  // Non-zero exit if everything failed, so CI/users notice.
+  if (ok === 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/podcastforge/backend/server.js
+++ b/podcastforge/backend/server.js
@@ -77,13 +77,21 @@ function clientIp(req) {
    pin the allowed CDN/script origins (so an injected <script src=evil> is
    blocked), forbid plugins/base-tag hijacking, and forbid framing of the app
    (clickjacking). The payment + animation CDNs are allow-listed explicitly. */
+// Origins the frontend talks to directly from the browser on the no-backend /
+// bring-your-own-key path (app.js calls these providers itself when the user
+// isn't signed into the backend). Authenticated users go through same-origin
+// /api/ai instead, but these must stay allow-listed or the static/BYO-key
+// generation flow breaks under CSP.
+const AI_ORIGINS = 'https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://integrate.api.nvidia.com https://api.openai.com https://api.groq.com';
 const CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' https://checkout.razorpay.com https://*.razorpay.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
-  "style-src 'self' 'unsafe-inline'",
+  // Google Fonts: the stylesheet (@import in style.css) is governed by
+  // style-src; the woff2 files it references load from fonts.gstatic.com.
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: https:",
-  "font-src 'self' data:",
-  "connect-src 'self' https://*.razorpay.com",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  `connect-src 'self' https://*.razorpay.com ${AI_ORIGINS}`,
   "frame-src https://*.razorpay.com https://api.razorpay.com",
   "object-src 'none'",
   "base-uri 'self'",
@@ -637,13 +645,18 @@ const server = http.createServer(async (req, res) => {
     const g = ratelimit.check('api', ip, 300, 5 * 60 * 1000);
     if (!g.ok) return tooMany(res, g.retryAfter);
   }
-  // Brute-force / abuse protection on auth. Login + OAuth start share a tight
-  // window; signup is capped per hour to curb mass account creation.
+  // Brute-force / abuse protection on auth. Login gets a tight window; signup
+  // is capped per hour to curb mass account creation; OAuth start has its own
+  // moderate cap. A successful login/signup resets its bucket (see below) so
+  // legitimate users behind a shared IP aren't penalised by failed attempts.
   if (method === 'POST' && (url === '/api/auth/login' || url === '/api/auth/signup')) {
     const isLogin = url.endsWith('/login');
     const r = isLogin
       ? ratelimit.check('login', ip, 10, 15 * 60 * 1000)
       : ratelimit.check('signup', ip, 5, 60 * 60 * 1000);
+    if (!r.ok) return tooMany(res, r.retryAfter);
+  } else if (method === 'GET' && /^\/api\/auth\/(google|github)$/.test(url)) {
+    const r = ratelimit.check('oauth', ip, 20, 15 * 60 * 1000);
     if (!r.ok) return tooMany(res, r.retryAfter);
   }
 
@@ -655,8 +668,10 @@ const server = http.createServer(async (req, res) => {
         oauth: { google: oauthReady('google'), github: oauthReady('github') }
       });
     }
-    if (url === '/api/auth/signup' && method === 'POST') return await handleSignup(req, res);
-    if (url === '/api/auth/login' && method === 'POST') return await handleLogin(req, res);
+    // On success, clear the IP's auth bucket so accumulated failures from
+    // others sharing the IP don't lock this (now-proven-legitimate) user out.
+    if (url === '/api/auth/signup' && method === 'POST') { await handleSignup(req, res); ratelimit.reset('signup', ip); return; }
+    if (url === '/api/auth/login' && method === 'POST') { await handleLogin(req, res); ratelimit.reset('login', ip); return; }
 
     // ----- OAuth (unauthenticated) -----
     let m = url.match(/^\/api\/auth\/(google|github)$/);

--- a/podcastforge/backend/test/security.test.js
+++ b/podcastforge/backend/test/security.test.js
@@ -69,14 +69,18 @@ test('API key encryption roundtrips and rejects tampering', () => {
 });
 
 // ---- live server checks ----
-function request(port, method, path, headers) {
+function request(port, method, path, headers, body) {
   return new Promise((resolve, reject) => {
-    const req = http.request({ host: '127.0.0.1', port, method, path, headers }, (res) => {
-      let body = '';
-      res.on('data', (d) => (body += d));
-      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+    const payload = body == null ? null : (typeof body === 'string' ? body : JSON.stringify(body));
+    const hdrs = Object.assign({}, headers);
+    if (payload != null) hdrs['content-length'] = Buffer.byteLength(payload);
+    const req = http.request({ host: '127.0.0.1', port, method, path, headers: hdrs }, (res) => {
+      let buf = '';
+      res.on('data', (d) => (buf += d));
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: buf }));
     });
     req.on('error', reject);
+    if (payload != null) req.write(payload);
     req.end();
   });
 }
@@ -97,10 +101,26 @@ test('server sets security headers and throttles auth brute-force', async (t) =>
   assert.equal(health.headers['x-frame-options'], 'DENY');
 
   // 10 logins/15min are allowed; the 11th from the same IP must be 429.
+  // Use a well-formed body with bad credentials so we exercise the real login
+  // path (a 401), not the empty-body branch — and so the bucket isn't reset by
+  // a success.
+  const creds = { email: 'nobody@example.com', password: 'wrong-password-123' };
   let last;
   for (let i = 0; i < 12; i++) {
-    last = await request(port, 'POST', '/api/auth/login', { 'content-type': 'application/json' });
+    last = await request(port, 'POST', '/api/auth/login', { 'content-type': 'application/json' }, creds);
   }
   assert.equal(last.status, 429);
   assert.ok(last.headers['retry-after']);
+
+  // A successful login must clear the bucket so a shared IP isn't locked out.
+  ratelimit._reset();
+  await request(port, 'POST', '/api/auth/signup', { 'content-type': 'application/json' }, { email: 'real@example.com', password: 'strong-password-123' });
+  for (let i = 0; i < 9; i++) {
+    await request(port, 'POST', '/api/auth/login', { 'content-type': 'application/json' }, { email: 'real@example.com', password: 'nope' });
+  }
+  // 9 failures so far; a success now should reset, so the next 10 are allowed.
+  const good = await request(port, 'POST', '/api/auth/login', { 'content-type': 'application/json' }, { email: 'real@example.com', password: 'strong-password-123' });
+  assert.equal(good.status, 200);
+  const afterReset = await request(port, 'POST', '/api/auth/login', { 'content-type': 'application/json' }, { email: 'real@example.com', password: 'nope' });
+  assert.notEqual(afterReset.status, 429); // bucket was cleared by the success
 });

--- a/podcastforge/index.html
+++ b/podcastforge/index.html
@@ -23,6 +23,8 @@
     <div class="nav-links" id="navbar-links">
       <a href="#landing-hero" class="nav-landing-only">Home</a>
       <a href="#landing-features" class="nav-landing-only">Features</a>
+      <a href="#guide" class="nav-landing-only">Guide</a>
+      <a href="#faq" class="nav-landing-only">FAQ</a>
       <a href="#/generator" class="nav-workspace-only nav-route" style="display: none;">Generator</a>
       <a href="#/agent" class="nav-workspace-only nav-route" style="display: none;">Agent</a>
       <a href="#/discover" class="nav-workspace-only nav-route" style="display: none;">Discover</a>
@@ -503,10 +505,120 @@
       </div>
     </section>
 
+    <!-- User Manual / Guide -->
+    <section id="guide" class="guide-section">
+      <div class="guide-wrap">
+        <div class="guide-head reveal">
+          <h2 class="section-title">How to use PodcastForge efficiently</h2>
+          <p class="section-sub">From a podcast link to a week of content in five steps. Each tool hands its output to the next.</p>
+        </div>
+
+        <div class="guide-steps">
+          <div class="guide-step reveal">
+            <div class="guide-num">1</div>
+            <div class="guide-body">
+              <h3>Add an API key (bring your own)</h3>
+              <p>Open the workspace and paste any supported key in the key bar — Anthropic, OpenAI, Google Gemini, Groq, OpenRouter, or NVIDIA. PodcastForge auto-detects the provider. <b>Tip:</b> a free <b>Groq</b> or <b>Gemini</b> key also unlocks audio transcription, so you never need a paid OpenAI key just to transcribe.</p>
+            </div>
+          </div>
+          <div class="guide-step reveal">
+            <div class="guide-num">2</div>
+            <div class="guide-body">
+              <h3>Find a podcast &amp; pull its transcript</h3>
+              <p>Use <b>Discover</b> to search Apple Podcasts, or paste an Apple/Spotify/YouTube link, an RSS URL, or a show name into <b>Transcripts</b>. Episodes that publish a transcript are pulled instantly; for the rest, click <b>Generate from audio</b> to transcribe with your OpenAI, Groq, or Gemini key.</p>
+            </div>
+          </div>
+          <div class="guide-step reveal">
+            <div class="guide-num">3</div>
+            <div class="guide-body">
+              <h3>Generate repurposed content</h3>
+              <p>Send a transcript to the <b>Generator</b> and pick formats — blog post, X/Twitter thread, LinkedIn post, show notes, newsletter, and more. Run the <b>Agent</b> to auto-repurpose into several formats at once.</p>
+            </div>
+          </div>
+          <div class="guide-step reveal">
+            <div class="guide-num">4</div>
+            <div class="guide-body">
+              <h3>Go deeper with the specialist tools</h3>
+              <p><b>Content Miner</b> extracts quotes, hooks, and insights section by section. <b>Script Studio</b> drafts full episode scripts. <b>Music Brief</b> suggests intro/outro direction. <b>AI Stack Tracker</b> audits the tools mentioned in an episode.</p>
+            </div>
+          </div>
+          <div class="guide-step reveal">
+            <div class="guide-num">5</div>
+            <div class="guide-body">
+              <h3>Track usage &amp; manage keys</h3>
+              <p>Click your account chip (top-right) for today's usage against your plan, recent activity, and connected keys — including which of them can transcribe audio. The free plan has per-tool daily caps; the trial and paid plans are unlimited.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="guide-tips reveal">
+          <h3>Pro tips for speed</h3>
+          <ul>
+            <li><span class="tip-ic">⌨️</span> Press <b>Enter</b> in the Discover and Transcripts inputs to search/load without reaching for the mouse.</li>
+            <li><span class="tip-ic">🔁</span> Tools are chained — the <b>→ Generator</b>, <b>→ Agent</b>, and <b>→ Miner</b> buttons on a pulled transcript skip copy-paste entirely.</li>
+            <li><span class="tip-ic">🎙️</span> No published transcript? Pick a shorter episode (audio is capped at 25&nbsp;MB) and use <b>Generate from audio</b>.</li>
+            <li><span class="tip-ic">💸</span> Mix providers: a fast free model (Groq/Gemini) for drafts, a stronger model (Claude/GPT-4o) for final polish.</li>
+            <li><span class="tip-ic">📊</span> Watch the daily caps in your account panel so you don't get interrupted mid-workflow on the free plan.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section id="faq" class="faq-section">
+      <div class="faq-wrap">
+        <div class="faq-head reveal">
+          <h2 class="section-title">Frequently asked questions</h2>
+          <p class="section-sub">What PodcastForge is, how your keys are handled, and what each plan includes.</p>
+        </div>
+
+        <div class="faq-list">
+          <details class="faq-item reveal">
+            <summary>What is PodcastForge?</summary>
+            <div class="faq-a">PodcastForge turns any podcast episode into ready-to-publish content. Pull (or generate) a transcript, then repurpose it into blog posts, social threads, newsletters, show notes, episode scripts, and more — using your own AI provider key.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>Do I need to pay for an AI subscription?</summary>
+            <div class="faq-a">You bring your own API key, so you pay your provider directly for what you use. Several providers have generous free tiers — a free <b>Groq</b> or <b>Google Gemini</b> key is enough to both generate content and transcribe audio. PodcastForge's own Free plan adds daily caps; the trial and paid plans lift them.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>Which providers are supported?</summary>
+            <div class="faq-a">Anthropic (Claude), OpenAI, Google Gemini, Groq, OpenRouter, and NVIDIA NIM for content generation. For turning audio into transcripts, use an <b>OpenAI</b>, <b>Groq</b>, or <b>Gemini</b> key (Whisper / multimodal). The app auto-detects the provider from the key format.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>How are my API keys stored and used?</summary>
+            <div class="faq-a">If you're signed in, keys are stored <b>encrypted</b> (AES-256-GCM) on the server and used server-side to call providers — they're never returned to the browser. Without an account, your key stays in your browser and calls the provider directly. Either way you can remove a key anytime from your account panel.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>Can I transcribe an episode that has no transcript?</summary>
+            <div class="faq-a">Yes. In the Transcripts tool, episodes without a published transcript show a <b>Generate from audio</b> button that transcribes the audio with your OpenAI, Groq, or Gemini key. Audio is capped at 25&nbsp;MB per episode, so shorter episodes transcribe fastest. Your account panel shows which of your keys can transcribe.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>How does the free trial and pricing work?</summary>
+            <div class="faq-a">New accounts get a 15-day full trial with unlimited access. After that you can stay on the <b>Free</b> plan (per-tool daily caps), or choose <b>Fixed Pro</b> (unlimited, flat monthly) or <b>Pay-as-you-go</b>. You can switch plans anytime from the pricing section or paywall.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>Is explicit or adult content allowed?</summary>
+            <div class="faq-a">No. Podcasts flagged explicit/adult (via the iTunes/RSS flags) are filtered out of search and can't be pulled, and transcripts are screened so explicit material is blocked.</div>
+          </details>
+          <details class="faq-item reveal">
+            <summary>Can I sign in with Google or GitHub?</summary>
+            <div class="faq-a">Yes, when the operator has configured social login. Otherwise, email + password works out of the box. Either way your verified email identifies your account.</div>
+          </details>
+        </div>
+      </div>
+    </section>
+
     <!-- Footer -->
     <footer>
       <div class="footer-brand">🎙️ PodcastForge</div>
-      <div class="footer-copy">Bring-your-own-key content repurposing · Your keys never leave your browser</div>
+      <div class="footer-copy">Bring-your-own-key content repurposing · Manage and remove your keys anytime</div>
+      <div class="footer-links">
+        <a href="#landing-features">Features</a>
+        <a href="#guide">Guide</a>
+        <a href="#faq">FAQ</a>
+        <a href="#pricing">Pricing</a>
+      </div>
     </footer>
 
   <!-- Paywall Modal -->

--- a/podcastforge/style.css
+++ b/podcastforge/style.css
@@ -1567,6 +1567,10 @@ footer { border-top: 1px solid var(--border); padding: 32px 40px; display: flex;
 .ac-use-top { display: flex; justify-content: space-between; font-size: 12.5px; color: var(--text-secondary); margin-bottom: 5px; }
 .ac-bar { height: 6px; background: var(--bg-input); border-radius: 999px; overflow: hidden; }
 .ac-bar-fill { height: 100%; background: linear-gradient(90deg, var(--accent-violet), var(--accent-cyan)); border-radius: 999px; transition: width 0.3s ease; }
+.ac-tag { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--accent-cyan2); background: rgba(6,182,212,0.12); border: 1px solid rgba(6,182,212,0.3); border-radius: 4px; padding: 2px 5px; margin-left: 6px; vertical-align: middle; white-space: nowrap; }
+.ac-hint { font-size: 12px; line-height: 1.55; color: var(--text-muted); background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 9px 11px; margin-top: 10px; }
+.ac-hint b { color: var(--text-secondary); font-weight: 700; }
+.ac-hint-ok { color: var(--accent-green); background: rgba(16,185,129,0.08); border-color: rgba(16,185,129,0.25); }
 .ac-rm { background: transparent; border: 1px solid var(--border); color: var(--text-muted); border-radius: 5px; padding: 4px 10px; font-size: 11.5px; font-weight: 600; cursor: pointer; }
 .ac-rm:hover { border-color: var(--accent-red); color: var(--accent-red); }
 .ac-cur { background: transparent; border: 1px solid var(--border); color: var(--text-secondary); border-radius: 5px; padding: 4px 10px; font-size: 12px; font-weight: 600; cursor: pointer; margin-left: 6px; }
@@ -1601,6 +1605,8 @@ footer { border-top: 1px solid var(--border); padding: 32px 40px; display: flex;
 /* Marketing Pricing + footer must NOT bleed into the routed app workspace.
    They belong to the landing page only; in-app upgrades use the paywall modal. */
 .workspace-active #pricing,
+.workspace-active #guide,
+.workspace-active #faq,
 .workspace-active footer { display: none !important; }
 
 /* Cap + scroll all tool input boxes so none stretch the page. */
@@ -1717,4 +1723,80 @@ button:not(:disabled):active { transform: translateY(1px) scale(0.985); }
   .pf-stagger > * { opacity: 1; animation: none; }
   .pf-shake, .toast.show.error { animation: none; }
   .pf-invalid { animation: none; }
+}
+
+/* ============================================================
+   v2.6 — User manual (Guide) + FAQ landing sections
+   ============================================================ */
+.guide-section, .faq-section { padding: 80px 24px; max-width: 1000px; margin: 0 auto; }
+.guide-head, .faq-head { text-align: center; margin-bottom: 44px; }
+
+/* Numbered, chained how-to steps */
+.guide-steps { display: flex; flex-direction: column; gap: 14px; }
+.guide-step {
+  display: flex; gap: 18px; align-items: flex-start;
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius-lg); padding: 20px 22px;
+  transition: border-color var(--transition-smooth), transform var(--transition-smooth);
+}
+.guide-step:hover { border-color: var(--border-accent); transform: translateY(-2px); }
+.guide-num {
+  flex-shrink: 0; width: 38px; height: 38px; border-radius: 50%;
+  display: grid; place-items: center; font-weight: 800; font-size: 16px; color: #fff;
+  background: linear-gradient(135deg, var(--accent-violet), var(--accent-cyan));
+  box-shadow: var(--shadow-glow-violet);
+}
+.guide-body h3 { font-size: 16px; font-weight: 700; color: var(--text-primary); margin-bottom: 5px; }
+.guide-body p { font-size: 13.5px; line-height: 1.65; color: var(--text-secondary); }
+.guide-body b { color: var(--text-primary); font-weight: 600; }
+
+/* Pro-tips card */
+.guide-tips {
+  margin-top: 26px; background: linear-gradient(180deg, rgba(124,58,237,0.06), rgba(6,182,212,0.04));
+  border: 1px solid var(--border-accent); border-radius: var(--radius-lg); padding: 24px 26px;
+}
+.guide-tips h3 { font-size: 15px; font-weight: 700; color: var(--text-primary); margin-bottom: 14px; }
+.guide-tips ul { list-style: none; display: flex; flex-direction: column; gap: 11px; }
+.guide-tips li { display: flex; gap: 11px; font-size: 13.5px; line-height: 1.55; color: var(--text-secondary); }
+.guide-tips li b { color: var(--text-primary); font-weight: 600; }
+.tip-ic { flex-shrink: 0; }
+
+/* FAQ accordion — native <details> for accessibility (keyboard + no JS) */
+.faq-list { display: flex; flex-direction: column; gap: 10px; }
+.faq-item {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius-md); overflow: hidden; transition: border-color var(--transition-fast);
+}
+.faq-item[open] { border-color: var(--border-accent); }
+.faq-item summary {
+  list-style: none; cursor: pointer; padding: 17px 20px;
+  font-size: 14.5px; font-weight: 600; color: var(--text-primary);
+  display: flex; justify-content: space-between; align-items: center; gap: 14px;
+}
+.faq-item summary::-webkit-details-marker { display: none; }
+.faq-item summary::after {
+  content: '+'; font-size: 20px; font-weight: 400; color: var(--accent-violet2);
+  flex-shrink: 0; transition: transform var(--transition-smooth);
+}
+.faq-item[open] summary::after { transform: rotate(45deg); }
+.faq-item summary:hover { color: var(--accent-violet2); }
+.faq-a {
+  padding: 0 20px 18px; font-size: 13.5px; line-height: 1.7; color: var(--text-secondary);
+  animation: fadeIn 0.25s ease;
+}
+.faq-a b { color: var(--text-primary); font-weight: 600; }
+
+/* Footer quick links */
+.footer-links { display: flex; gap: 18px; flex-wrap: wrap; justify-content: center; margin-top: 14px; }
+.footer-links a { color: var(--text-muted); font-size: 13px; text-decoration: none; transition: color var(--transition-fast); }
+.footer-links a:hover { color: var(--accent-violet2); }
+
+@media (max-width: 640px) {
+  .guide-section, .faq-section { padding: 56px 18px; }
+  .guide-step { padding: 16px; gap: 14px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .guide-step:hover { transform: none; }
+  .faq-item[open] summary::after { transition: none; }
+  .faq-a { animation: none; }
 }


### PR DESCRIPTION
## Why this PR

PR #12 was merged at commit `4c3e2b7` — **before** three later commits on the same branch. As a result the merged code shipped an **app-breaking Content-Security-Policy regression**. This PR lands the fix plus the follow-on docs and tooling.

## Commits

**1. `804377a` — Fix regressions from self-review (the important one)**
The CSP added in PR #12 was too strict and broke real flows:
- **`connect-src`** blocked the frontend's direct browser→LLM-provider calls (the no-backend / bring-your-own-key path), so generation failed for any user without a backend session. Now allow-lists the provider origins.
- **Fonts**: `style-src`/`font-src` omitted `fonts.googleapis.com` / `fonts.gstatic.com`, so the `@import` in `style.css` and its woff2 files were blocked and all three custom fonts fell back to system fonts. Now allowed.
- **GitHub OAuth** hard-failed on a transient `/user/emails` error after the rewrite; restores a fallback to the (verified) public profile email.
- **Auth rate limiting** counted successful logins and is IP-keyed → shared-NAT lockout; now resets an IP's bucket on a successful login/signup, and OAuth-start has its own throttle.
- Strengthens the security test to POST a well-formed failing login and adds reset-on-success coverage.

**2. `7703f5b` — Account transcribe hint + user manual + FAQ**
- Account panel surfaces which stored keys can transcribe audio (OpenAI/Groq/Gemini), nudging free Groq/Gemini so transcription needs no paid OpenAI key.
- New landing sections: a step-by-step user manual and an accessible `<details>` FAQ; nav + footer links.

**3. `05571b6` — Playwright visual-capture tooling**
- `npm run screenshots` (in `backend/`) boots the server and captures landing, Guide, FAQ, workspace, the account transcribe-hint, and a mobile FAQ shot to `podcastforge/screenshots/`.

## Verification

- `node --test` (backend) → 6/6 pass.
- Live server confirms the corrected CSP (fonts + provider origins) and the OAuth-start throttle.
- Screenshot tooling wiring verified (server boot + health-check + graceful failure + cleanup); the Chromium download needs egress to `cdn.playwright.dev`.

https://claude.ai/code/session_017bqiPMjQrGPJJExKam5U5U

---
_Generated by [Claude Code](https://claude.ai/code/session_017bqiPMjQrGPJJExKam5U5U)_